### PR TITLE
Ajax.ts - moved CORS header configuration from the request method to …

### DIFF
--- a/src/labkey/Ajax.ts
+++ b/src/labkey/Ajax.ts
@@ -164,6 +164,17 @@ function configureHeaders(xhr: XMLHttpRequest, config: RequestOptions, options: 
         headers['X-Requested-With'] = 'XMLHttpRequest';
     }
 
+    // SNPRC
+    // CSRF is getting initialized too early for CORS requests
+    // CSRF should be set after the user authenticates (LABKEY.CSRF = CSRF from the login response)
+    // 1 - if this is a CORS request (baseURL is defined), then replace the value of CSRF with the updated value in the server context (LABKEY)
+    // 2 - If the request is to a remote server then the baseURL will be configured in the LABKEY configuration. In this case, credentials need to be enabled to trigger a CORS request
+    const { baseURL } = getServerContext();
+    if (baseURL) {
+        DEFAULT_HEADERS[CSRF_HEADER] = getServerContext().CSRF;
+        xhr.withCredentials = true;
+    }
+
     for (let k in DEFAULT_HEADERS) {
         if (DEFAULT_HEADERS.hasOwnProperty(k)) {
             xhr.setRequestHeader(k, DEFAULT_HEADERS[k]);
@@ -237,7 +248,6 @@ function configureOptions(config: RequestOptions): ConfiguredOptions {
  * Make a XMLHttpRequest nominally to a LabKey instance. Includes success/failure callback mechanism,
  * HTTP header configuration, support for FormData, and parameter encoding amongst other features.
  * 
- * SNPRC: Added CORS configuration
  * 
  */
 export function request(config: RequestOptions): XMLHttpRequest {
@@ -255,16 +265,6 @@ export function request(config: RequestOptions): XMLHttpRequest {
     };
 
     xhr.open(options.method, options.url, true);
-
-    // If the request is to a remote server then the baseURL will be configured in the LABKEY configuration. In this case, we need to enable 
-    // credentials to trigger a CORS request
-    const { baseURL } = getServerContext();
-    const noContextPath = !( getServerContext().hasOwnProperty('contextPath') && getServerContext().contextPath != null);
-
-    if (location.protocol + '//' + location.host + (noContextPath ? '/' : getServerContext().contextPath + '/') != baseURL ) {
-        xhr.withCredentials = true;
-    }
-    
 
     // configure headers after request is open
     configureHeaders(xhr, config, options);

--- a/src/labkey/query/Rows.ts
+++ b/src/labkey/query/Rows.ts
@@ -615,7 +615,7 @@ export function selectRows(options: ISelectRowsOptions): XMLHttpRequest {
         throw 'You must specify a queryName!';
     }
 
-    // Create absolute path if the LABKEY.baseURL is configured (assume remote server), otherwise use the relative URL from buildURL.
+    // SNPRC: Create absolute path if the LABKEY.baseURL is configured (assume remote server), otherwise use the relative URL from buildURL.
     // TODO: refactor into buildURL (ActionURL.ts)
     let url: string;
     const { baseURL } = getServerContext();
@@ -704,8 +704,19 @@ export interface IQueryRequestOptions {
  */
 function sendRequest(options: IQueryRequestOptions): XMLHttpRequest {
 
+    // SNPRC: Create absolute path if the LABKEY.baseURL is configured (assume remote server), otherwise use the relative URL from buildURL.
+    // TODO: refactor into buildURL (ActionURL.ts)
+    let url: string;
+    const { baseURL } = getServerContext();
+    if (baseURL) {
+        url = baseURL + buildURL('query', options.action, options.containerPath);
+    }
+    else {
+        url = buildURL('query', options.action, options.containerPath);
+    }
+
     return request({
-        url: buildURL('query', options.action, options.containerPath),
+        url: url,
         method: 'POST',
         success: getCallbackWrapper(getOnSuccess(options), options.scope),
         failure: getCallbackWrapper(getOnFailure(options), options.scope, true),


### PR DESCRIPTION
…the configureHeaders method where it belongs.

	       Added support in configureHeaders for the CSRF token to be set after the user authenticates.
Rows.ts - Added baseURL config from LABKEY.baseURL in sendRequest method to enable POST requests to utilize CORS config.